### PR TITLE
fix: check if node exist before calling `contains` method

### DIFF
--- a/src/FocusWithin.js
+++ b/src/FocusWithin.js
@@ -129,6 +129,10 @@ class FocusWithin extends React.Component {
         )
       }
     }
+    // return false in case parentNode does not exist
+    if (parentNode == null) {
+      return false
+    }
     return parentNode.contains(node)
   }
 


### PR DESCRIPTION
Fixes #6